### PR TITLE
0.7.5

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -1,5 +1,5 @@
 [![License: MIT](https://img.shields.io/badge/License-MIT-blue.svg)](https://opensource.org/licenses/MIT)
-[![Version](https://img.shields.io/badge/Version-0.7.3-blue.svg)](https://pypi.org/project/pythontk/)
+[![Version](https://img.shields.io/badge/Version-0.7.5-blue.svg)](https://pypi.org/project/pythontk/)
 [![CoreUtils Tests](https://img.shields.io/badge/CoreUtils-Passing-brightgreen.svg)](../test/ptk_test.py#CoreUtilsTest)
 [![FileUtils Tests](https://img.shields.io/badge/FileUtils-Passing-brightgreen.svg)](../test/ptk_test.py#FileUtilsTest)
 [![ImgUtils Tests](https://img.shields.io/badge/ImgUtils-Passing-brightgreen.svg)](../test/ptk_test.py#ImgUtilsTest)

--- a/pythontk/__init__.py
+++ b/pythontk/__init__.py
@@ -5,7 +5,7 @@ import importlib
 import pkgutil
 
 __package__ = "pythontk"
-__version__ = "0.7.3"
+__version__ = "0.7.5"
 
 CLASS_TO_MODULE = {}
 METHOD_TO_MODULE = {}

--- a/pythontk/file_utils.py
+++ b/pythontk/file_utils.py
@@ -70,15 +70,14 @@ class FileUtils:
             returned_type (str/list): Return files and directories. Can be a single string or a list of strings.
                                       (valid: 'file'(default), 'filename', 'filepath', 'dir', 'dirpath')
             recursive (bool): When False, return the contents of the root dir only. When True, includes sub-directories.
-            num_threads (int): The number of threads to use for processing directories and files.
-                               If set to 1 or 0, multithreading will not be used.
+            num_threads (int): Specifies the number of threads to use for processing directories and files.
+                           A value of 0 (default) means no multithreading, -1 means use all available cores.
             inc_files (str/list): Include only specific files.
             exc_files (str/list): Exclude specific files.
             inc_dirs (str/list): Include only specific child directories.
             exc_dirs (str/list): Exclude specific child directories.
             group_by_type (bool): When set to True, returns a dictionary where each key corresponds to a 'returned_type',
                                   and the value is a list of items of that type.
-
         Returns:
             list/dict: A list or dictionary containing the results based on the `returned_type` and `group_by_type` parameters.
 
@@ -125,9 +124,11 @@ class FileUtils:
             return temp_result
 
         if num_threads > 1:
+            import multiprocessing
             from concurrent.futures import ThreadPoolExecutor, as_completed
 
-            with ThreadPoolExecutor(max_workers=num_threads) as executor:
+            num_cores = multiprocessing.cpu_count() if num_threads == -1 else num_threads
+            with ThreadPoolExecutor(max_workers=num_cores) as executor:
                 futures = {
                     executor.submit(process_directory, root, dirs, files): (
                         root,
@@ -146,6 +147,7 @@ class FileUtils:
                 data = process_directory(root, dirs, files)
                 for opt in options:
                     grouped_result[opt].extend(data[opt])
+
 
         return (
             grouped_result

--- a/pythontk/iter_utils.py
+++ b/pythontk/iter_utils.py
@@ -185,6 +185,7 @@ class IterUtils:
         map_func: Optional[Callable] = None,
         check_unmapped: bool = False,
         nested_as_unit: bool = False,
+        basename_only: bool = False,
     ) -> List:
         """Filters the given list based on inclusion/exclusion criteria using shell-style wildcards. This method can also apply
         the filter to nested structures like lists, tuples, or sets. If 'nested_as_unit' is True, then the entire structure is
@@ -211,22 +212,30 @@ class IterUtils:
                 the original item is included or excluded in the result accordingly. Defaults to False.
             nested_as_unit (bool, optional): Whether to consider the entire nested structure as a single entity for filtering.
                 If True, the entire nested structure will be included or excluded if any of its elements match the inclusion or exclusion criteria.
+            basename_only (bool, optional): Use only the base name of the file paths when filtering.
 
         Returns:
             list: The filtered list.
         """
         from fnmatch import fnmatchcase
+        import os
 
         inc = list(cls.make_iterable(inc))
         exc = list(cls.make_iterable(exc))
 
         def match_item(item: Union[str, int], patterns: List[Union[str, int]]) -> bool:
-            return any(
-                fnmatchcase(str(item), pattern)
-                if isinstance(pattern, str)
-                else item == pattern
-                for pattern in patterns
-            )
+            for pattern in patterns:
+                check_item = (
+                    os.path.basename(str(item)) if basename_only else str(item)
+                )  # Adjusted line
+                match_result = (
+                    fnmatchcase(check_item, pattern)
+                    if isinstance(pattern, str)
+                    else item == pattern
+                )
+                if match_result:
+                    return True
+            return False
 
         def check_item(item):
             try:


### PR DESCRIPTION
- file_utils.get_dir_contents: The `num_threads` parameter now uses all available threads if given a value of -1.
- iter_utils.filter_list: Now accepts an additional parameter `basename_only`, which allows to filter based on only the base name of a file string as opposed to evaluating the entire string.